### PR TITLE
Raise an error when there's a missing interpolation

### DIFF
--- a/lib/ansible_doc_generator/doc_generator/interpolator.rb
+++ b/lib/ansible_doc_generator/doc_generator/interpolator.rb
@@ -15,7 +15,7 @@ module AnsibleDocGenerator
       end
 
       def call
-        variables_interpolated = Interpolator::VariableExtractor.new(input, task).call
+        variables_interpolated = Interpolator::VariableExtractor.new(input, task, role_path).call
         Interpolator::FileExtractor.new(variables_interpolated, role_path).call
       end
 

--- a/spec/ansible_doc_generator/doc_generator/interpolator/variable_extractor_spec.rb
+++ b/spec/ansible_doc_generator/doc_generator/interpolator/variable_extractor_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe AnsibleDocGenerator::DocGenerator::Interpolator::VariableExtractor do
-  subject { described_class.new(input, task) }
+  let(:role_path) { 'fake/path' }
+
+  subject { described_class.new(input, task, role_path) }
 
   describe '#call' do
     context 'basic interpolation' do
@@ -79,6 +81,22 @@ describe AnsibleDocGenerator::DocGenerator::Interpolator::VariableExtractor do
 
       it 'returns the expected output' do
         expect(subject.call).to eq 'Add the line "eval \"$(/usr/lib/rbenv/plugins/rbenv-vars/bin/rbenv-vars)\"" in /etc/bashrc just after "^rbenv-vars"'
+      end
+    end
+
+    context 'missing interpolation' do
+      let(:input) { 'apt install -y #{apt>pkg | join: \' \'}' }
+      let(:task) do
+        {
+          'name' => 'Install required packages',
+          'package' => {
+            'pkg' => ["dirmngr", "gnupg", "apt-transport-https", "ca-certificates"]
+          }
+        }
+      end
+
+      it 'raises an error' do
+        expect { subject.call }.to raise_error(AnsibleDocGenerator::DocGenerator::Interpolator::VariableExtractor::MissingInterpolationError)
       end
     end
   end


### PR DESCRIPTION
It was failing without telling you why. Now it shows the interpolation, the hash is using and the file hwere it's happening.