### PR TITLE
docs: Wrong gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For instance, given the following task inside the role `nginx/tasks/main.yml`, i
 ## Installation
 
 ```
-$ gem install ansible-doc-generator
+$ gem install ansible_doc_generator
 ```
 
 ## Usage


### PR DESCRIPTION
https://rubygems.org/gems/ansible_doc_generator


```
# gem -v
3.2.22

# gem install ansible-doc-generator
ERROR:  Could not find a valid gem 'ansible-doc-generator' (>= 0) in any repository
ERROR:  Possible alternatives: ansible_doc_generator
```
